### PR TITLE
Fix Page Up/Down in notebook editor cells

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.editor.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.editor.test.ts
@@ -102,7 +102,7 @@ suite('Notebook Editor', function () {
 		assert.strictEqual(vscode.window.visibleNotebookEditors.length, 2);
 	});
 
-	test('Notebook Editor Event - onDidChangeVisibleNotebookEditors on open/close', async function () {
+	test.skip('Notebook Editor Event - onDidChangeVisibleNotebookEditors on open/close', async function () { // TODO@rebornix https://github.com/microsoft/vscode/issues/139958
 		const openedEditor = utils.asPromise(vscode.window.onDidChangeVisibleNotebookEditors);
 		const resource = await utils.createRandomFile(undefined, undefined, '.nbdtest');
 		await vscode.window.showNotebookDocument(resource);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/webview.test.ts
@@ -242,7 +242,7 @@ suite('vscode API - webview', () => {
 	});
 
 
-	test('webviews should only be able to load resources from workspace by default', async () => {
+	test.skip('webviews should only be able to load resources from workspace by default', async () => { // TODO@mjbvz https://github.com/microsoft/vscode/issues/139960
 		const webview = _register(vscode.window.createWebviewPanel(webviewId, 'title', {
 			viewColumn: vscode.ViewColumn.One
 		}, {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.64.0",
-  "distro": "1f70d5b8b91ef1ab0ebf90665d4222a0bf4bd979",
+  "distro": "553bb9d3803948fcccf1a35374942d8aba9c9c73",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -800,6 +800,10 @@ function createKeyboardNavigationEventFilter(container: HTMLElement, keybindingS
 	let inChord = false;
 
 	return event => {
+		if (event.toKeybinding().isModifierKey()) {
+			return false;
+		}
+
 		if (inChord) {
 			inChord = false;
 			return false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #139979

pageSize is being calculated incorrectly in [cursorCommon.ts#L125](https://github.com/microsoft/vscode/blob/main/src/vs/editor/common/controller/cursorCommon.ts#L125) as layoutinfo.height corresponds to cell height in case of notebook editor cells. 

To fix this, new actions corresponding to <kbd>PgUp</kbd> and <kbd>PgDown</kbd> have been added.


<h2>Before:</h2>

![before](https://user-images.githubusercontent.com/26321479/147846572-ac97b2e0-fd34-41ed-aa31-f444710d65a7.gif)

<h2>After:</h2>

![after](https://user-images.githubusercontent.com/26321479/147846578-c7b71b7d-e61e-4488-a54e-2e2f9e24539c.gif)

